### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Currently, both main and secondary views inside `FABRevealLayout` should have th
 
 ```groovy
 dependencies{
-	compile 'com.truizlop.fabreveallayout:library:1.0.0'
+	implementation 'com.truizlop.fabreveallayout:library:1.0.0'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.